### PR TITLE
Allow HTTPS links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A list of all your education, each education will follow this format
 A list of all your experience, each experience will follow this format
 ```
 - company: Company name
-  link: Link to company (optional)
+  link: Link to company (eg. https://google.com)(optional)
   job_title: Job title
   dates: Date Range (eg. November 2016 - present)
   quote: >
@@ -74,7 +74,7 @@ A list of all your experience, each experience will follow this format
 A list of all your projects, each project will follow this format
 ```
 - name: Project name
-  link: Link to project (eg. sproogen.github.io/modern-resume-theme)(optional)
+  link: Link to project (eg. https://sproogen.github.io/modern-resume-theme)(optional)
   github: Github page for project (eg. sproogen/modern-resume-theme)(optional)
   quote: >
     Short overview of the project (optional)

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -5,7 +5,7 @@
       <div class="col-xs-12 col-sm-4 col-md-3 col-print-12 left-column">
         <h4 class="name">
           {%- if experience.link -%}
-            <a href="http://{{ experience.link }}" target="_blank">
+            <a href="{{ experience.link }}" target="_blank">
           {%- endif -%}
             {{ experience.company }}
           {%- if experience.link -%}

--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -5,7 +5,7 @@
       <div class="col-xs-12 col-sm-4 col-md-3 col-print-12 left-column">
         <h4>{{ project.name }}</h4>
         {%- if project.link -%}
-          <a href="http://{{ project.link }}" target="_blank" class="project-link">{{ project.link }}</a>
+          <a href="{{ project.link }}" target="_blank" class="project-link">{{ project.link }}</a>
         {%- endif -%}
         <p class="no-print">
           <a href="https://github.com/{{ project.github }}" target="_blank">

--- a/_test/_data/experience.yml
+++ b/_test/_data/experience.yml
@@ -1,5 +1,5 @@
 - company: Company 1
-  link: google.com
+  link: https://google.com
   job_title: Job title 1
   dates: November 2016 - present
   quote: >

--- a/_test/_data/projects.yml
+++ b/_test/_data/projects.yml
@@ -1,6 +1,6 @@
 # Project template
 - name: Project 1
-  link: sproogen.github.io/modern-resume-theme
+  link: https://sproogen.github.io/modern-resume-theme
   github: sproogen/modern-resume-theme
   quote: >
     Short overview of the project


### PR DESCRIPTION
Allow linking to HTTPS URLs by allowing company and project entries to provide the URL's protocol instead of assuming only `http`.

**Note:** This is a breaking change since existing links will become relative links (as they don't specify a protocol).