### PR TITLE
Add option to include a phone on the header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -90,6 +90,11 @@
           Email: <a href="mailto:{{ site.email }}" target="_blank">{{ site.email | escape }}</a>
         </p>
       {%- endif -%}
+      {%- if site.phone -%}
+        <p>
+          Phone: {{ site.phone | escape }}
+        </p>
+      {%- endif -%}
       {%- if site.website -%}
         <p>
           Web: <a href="http://{{ site.website }}" target="_blank">{{ site.website | escape }}</a>


### PR DESCRIPTION
Some people would like to have their phone on the online resume for a more direct contact.