### PR TITLE
Make GitHub project link optional in project section

### DIFF
--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -7,11 +7,13 @@
         {%- if project.link -%}
           {% include a.html href=project.link class="project-link" %}{{ project.link }}</a>
         {%- endif -%}
-        <p class="no-print">
-          <a href="https://github.com/{{ project.github }}" target="_blank">
-            <i class="fa fa-github" title="{{ project.name }} Github link"></i>
-          </a>
-        </p>
+        {%- if project.github -%}
+          <p class="no-print">
+            <a href="https://github.com/{{ project.github }}" target="_blank">
+              <i class="fa fa-github" title="{{ project.name }} Github link"></i>
+            </a>
+          </p>
+        {%- endif -%}
       </div>
       <div class="col-xs-12 col-sm-8 col-md-9 col-print-12">
         {%- if project.quote -%}


### PR DESCRIPTION
Adds a check to see if GitHub link is provided before displaying it.

Fixes #44 by adding a conditional to check to see if GitHub link is provided.

This lets you hide GitHub logo when the project is not on GitHub by commenting the line.