### PR TITLE
Use rem instead of em

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -12,11 +12,11 @@ button, input[type="button"], input[type="reset"], input[type="submit"] {
   cursor: pointer;
   display: inline-block;
   font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
-  font-size: 1em;
+  font-size: 1rem;
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: 0.75em 1.5em;
+  padding: 0.75rem 1.5rem;
   text-decoration: none;
   transition: background-color 150ms ease;
   user-select: none;
@@ -38,53 +38,53 @@ button, input[type="button"], input[type="reset"], input[type="submit"] {
 fieldset {
   background-color: #f7f7f7;
   border: 1px solid #ddd;
-  margin: 0 0 0.75em;
-  padding: 1.5em; }
+  margin: 0 0 0.75rem;
+  padding: 1.5rem; }
 
 input,
 label,
 select {
   display: block;
   font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
-  font-size: 1em; }
+  font-size: 1rem; }
 
 label {
   font-weight: 600;
-  margin-bottom: 0.375em; }
+  margin-bottom: 0.375rem; }
   label.required::after {
     content: "*"; }
   label abbr {
     display: none; }
 
 select {
-  margin-bottom: 1.5em;
+  margin-bottom: 1.5rem;
   max-width: 100%;
   width: auto; }
 
 dl {
-  margin-bottom: 0.75em; }
+  margin-bottom: 0.75rem; }
   dl dt {
     font-weight: bold;
-    margin-top: 0.75em; }
+    margin-top: 0.75rem; }
   dl dd {
     margin: 0; }
 
 table {
   border-collapse: collapse;
   font-feature-settings: "kern", "liga", "tnum";
-  margin: 0.75em 0;
+  margin: 0.75rem 0;
   table-layout: fixed;
   width: 100%; }
 
 th {
   border-bottom: 1px solid #a6a6a6;
   font-weight: 600;
-  padding: 0.75em 0;
+  padding: 0.75rem 0;
   text-align: left; }
 
 td {
   border-bottom: 1px solid #ddd;
-  padding: 0.75em 0; }
+  padding: 0.75rem 0; }
 
 tr,
 td,
@@ -96,7 +96,7 @@ hr {
   border-left: 0;
   border-right: 0;
   border-top: 0;
-  margin: 1.5em 0; }
+  margin: 1.5rem 0; }
 
 img,
 picture {
@@ -179,7 +179,7 @@ body {
 }
 
 .header-right p {
-  font-size: 1.6em;
+  font-size: 1.6rem;
   text-align: right;
 }
 

--- a/_sass/icons.scss
+++ b/_sass/icons.scss
@@ -4,7 +4,7 @@ ul.icons a:hover {
 
 ul.icons li {
   display: inline-block;
-  padding-left: 0.75em;
+  padding-left: 0.75rem;
 }
 
 ul.icons a {
@@ -13,9 +13,9 @@ ul.icons a {
   -ms-transition: background-color 0.25s ease-in-out;
   transition: background-color 0.25s ease-in-out;
   display: inline-block;
-  width: 2.75em;
-  height: 2.75em;
-  line-height: 2.8em;
+  width: 2.75rem;
+  height: 2.75rem;
+  line-height: 2.8rem;
   text-align: center;
   border: 0;
   box-shadow: none;
@@ -31,7 +31,7 @@ ul.icons a {
 
 .icons {
   padding: 0;
-  font-size: 1em;
+  font-size: 1rem;
   margin-bottom:20px;
   text-align: right;
 }

--- a/_sass/modern-resume-theme.scss
+++ b/_sass/modern-resume-theme.scss
@@ -59,14 +59,14 @@
 }
 
 .layout {
-  margin-top: 3em;
+  margin-top: 3rem;
 
   .details {
     text-align: left;
 
     p {
       margin-bottom: 3px;
-      font-size: 1.6em;
+      font-size: 1.6rem;
       text-align: inherit;
       font-weight: 300;
 
@@ -90,19 +90,19 @@
     }
 
     .fa {
-      font-size: 2em;
+      font-size: 2rem;
     }
 
     .link {
-      font-size: 1.5em;
+      font-size: 1.5rem;
     }
 
     h4 {
-      margin-bottom: 0.1em;
+      margin-bottom: 0.1rem;
       font-weight: 500;
 
       @media print {
-        margin-bottom: 0.2em;
+        margin-bottom: 0.2rem;
       }
 
       a {
@@ -172,14 +172,14 @@
 }
 
 p.quote {
-  font-size: 1.4em;
+  font-size: 1.4rem;
   font-style: italic;
-  padding: 1em 2.5em;
+  padding: 1rem 2.5rem;
   text-align: center;
 
   @media print {
     text-align: left;
-    padding: 0em 1em;
-    margin-top: 1em;
+    padding: 0rem 1rem;
+    margin-top: 1rem;
   }
 }

--- a/_sass/type.scss
+++ b/_sass/type.scss
@@ -2,11 +2,11 @@ body {
   color: #333;
   font-family: Roboto, sans-serif;
   font-feature-settings: "kern", "liga", "pnum";
-  font-size: 1em;
+  font-size: 1rem;
   line-height: 1.5;
 
   @media print {
-    font-size: 0.9em;
+    font-size: 0.9rem;
   }
 }
 
@@ -17,13 +17,13 @@ h4,
 h5,
 h6 {
   font-family: Roboto, sans-serif;
-  font-size: 1em;
+  font-size: 1rem;
   line-height: 1.2;
-  margin: 0 0 0.75em;
+  margin: 0 0 0.75rem;
 }
 
 p {
-  margin: 0 0 0.75em; }
+  margin: 0 0 0.75rem; }
 
 a {
   color: #477dca;
@@ -36,19 +36,19 @@ color: #355e98;
 }
 
 h1 {
-  font-size: 4em;
-  margin-bottom: 0.1em;
+  font-size: 4rem;
+  margin-bottom: 0.1rem;
   font-weight: 500;
 }
 
 h2 {
   font-weight: 300;
-  font-size: 2em;
+  font-size: 2rem;
 }
 
 h3 {
   font-weight: 300;
-  font-size: 3em;
+  font-size: 3rem;
   text-align: center;
   border-bottom: dashed 2px #CCCCCC;
   padding-bottom: 10px;
@@ -61,17 +61,17 @@ h3 {
 
 h4 {
   font-weight: 300;
-  font-size:2.5em;
+  font-size:2.5rem;
   margin-bottom:3px;
 }
 
 p, ul {
-  font-size: 1.6em;
+  font-size: 1.6rem;
   text-align: justify;
 }
 
 a i {
-  font-size:1.6em;
+  font-size:1.6rem;
 }
 
 mark {


### PR DESCRIPTION
While em is relative to the font-size of its direct or nearest parent, rem is only relative to the HTML (root) font-size.
In the case of nested lists or nested paragraphs text size changes with respect to the parent element and becomes way too large.