### PR TITLE
Add clarity to README regarding the support and use of Dark Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Dark mode is configured via _config.yml
 darkmode: true/false
 ```
 
+Dark mode is only be presented on the client device if they are using a browser that supports this feature and have it enabled.
+
 ##### _data/education.yml
 A list of all your education, each education will follow this format
 ```


### PR DESCRIPTION
Issue #93 highlights that support for Dark Mode may be slightly confusing. 

I have added clarification to the README to highlight that Dark Mode will only be presented on a supported device where this feature is enabled.