### PR TITLE
Updated icon references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # modern-resume-theme [![Gem Version](https://badge.fury.io/rb/modern-resume-theme.svg)](https://badge.fury.io/rb/modern-resume-theme) [![Build Status](https://travis-ci.com/sproogen/modern-resume-theme.svg?branch=master)](https://travis-ci.com/sproogen/modern-resume-theme)
 
+*This is the modified version of the amazing modern-resume-theme from Sproogen. This theme expands the use of icons beyong `font-awesome-brand` making it easier to create custom icons for more flexible usage.*
+
 *A modern simple static resume template and theme. Powered by Jekyll and GitHub pages.*
 *Host your own resume on GitHub for **free!***
 

--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,13 @@ about_content: | # this will include new lines to allow paragraphs
     - <a href="google.com">Links</a>
     - Images
 
+# whatsnew Section
+# whatsnew_title: Updates #(Use this to override about whatsnew section title)
+whatsnew_content: | # this will include new lines to allow paragraphs
+  This is where you can write a little more about yourself. You could title this section **Interests** and include some of your other interests.
+
+  Or you could title it **Skills** and write a bit more about things that make you more desirable, like *leadership* or *teamwork*
+
 # Projects Section
 # projects_title: Projects #(Use this to override about projects section title)
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,4 +18,6 @@
   {%- if jekyll.environment == 'production' and site.gtag -%}
     {%- include gtag.html -%}
   {%- endif -%}
+  
+  <meta name="google-site-verification" content= {{ site.google_site_verification }} />
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -97,6 +97,20 @@
             </a>
           </li>
         {%- endif -%}
+        {%- if site.google_scholar_id -%}
+          <li>
+            <a target="_blank" href="https://scholar.google.com/citations?user={{ site.google_scholar_id | escape }}" class="button button--sacnite button--round-l">
+              <i class="fas fa-graduation-cap" title="Google Scholar"></i>
+            </a>
+          </li>
+        {%- endif -%}
+        {%- if site.email_via_form -%}
+          <li>
+            <a target="_blank" href="{{ site.email_via_form | escape }}" class="button button--sacnite button--round-l">
+              <i class="fas fa-envelope" title="Email Me via Form"></i>
+            </a>
+          </li>
+        {%- endif -%}
         {% for link in site.additional_links %}
           <li>
             {% include a.html href=link.url class="button button--sacnite button--round-l" %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -114,7 +114,7 @@
         {% for link in site.additional_links %}
           <li>
             {% include a.html href=link.url class="button button--sacnite button--round-l" %}
-              <i class="fab {{ link.icon }}" title="{{ link.title | escape }}"></i>
+              <i class="{{ link.icon }}" title="{{ link.title | escape }}"></i>
             </a>
           </li>
         {% endfor %}

--- a/_includes/whatsnew.html
+++ b/_includes/whatsnew.html
@@ -1,4 +1,4 @@
-<div class="container more-container">
+<div class="container whatsnew-container">
   <h3>{{ site.whatsnew_title | default: "Latest Developments" }}</h3>
   <div class="row clearfix">
     <div class="col-md-12">

--- a/_includes/whatsnew.html
+++ b/_includes/whatsnew.html
@@ -1,0 +1,8 @@
+<div class="container more-container">
+  <h3>{{ site.whatsnew_title | default: "Latest Developments" }}</h3>
+  <div class="row clearfix">
+    <div class="col-md-12">
+      {{ site.whatsnew_content | strip | markdownify }}
+    </div>
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,10 @@
 
       {%- include about.html -%}
 
+      {%- if site.whatsnew_content -%}
+        {%- include whatsnew.html -%}
+      {%- endif -%}
+
       {%- if site.data.projects.size > 0 -%}
         {%- include projects.html -%}
       {%- endif -%}

--- a/_test/_config.yml
+++ b/_test/_config.yml
@@ -41,6 +41,12 @@ about_content: > # this means to ignore newlines until the next config item.
 
   You can even add paragraphs by using empty lines like this and add anything else markdown supports.
 
+# whatsnew Section
+# whatsnew_title: Updates #(Use this to override about whatsnew section title)
+whatsnew_content: > # this means to ignore newlines until the next config item.
+  This is where you can write a little more about yourself. You could title this section **Interests** and include some of your other interests. Or you could title it **Skills**
+  and write a bit more about things that make you more desirable, like *leadership* or *teamwork*
+
 # Projects Section
 # projects_title: Projects #(Use this to override about projects section title)
 


### PR DESCRIPTION
Hi,

I added icons to submit email via custom id, a google scholar form. But, most importantly, I have changed the additional-links icon references to be more open - and removed the fab exclusive. Now, the user must specify the entire string "fas ______" or whatever. This helped with using custom icons outside brands. 

Thanks again for sharing your awesome work - much appreciated.

RJ