### PR TITLE
Add HTML element id to support deep linking

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,11 @@
       {%- if site.version == 2 -%}
         {% for section in site.content %}
           <div class="container {{ section.layout }}-container">
-            <h3>{{ section.title }}</h3>
+            {%- if section.id -%}
+              <h3 id="{{ section.id }}">{{ section.title }}</h3>
+            {% else %}
+              <h3>{{ section.title }}</h3>
+            {%- endif -%}
             {% include {{ section.layout | prepend: "section-" | append: ".html" }} content=section.content %}
           </div>
         {% endfor %}


### PR DESCRIPTION
Simple PR to let a user add ids to section title elements. This lets users deep link to a section in their resume.