### PR TITLE
Adds the ability to reference header anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ When dark mode is `true` the site will show the dark theme for everyone
 When dark mode is `false` the site will not show the dark theme, but it will still respect the users device preferences  
 When dark mode is `never` the site will never be shown in the dark theme
 
+#### Heading Anchors
+You can link to section titles using a Markdown anchor link, e.g.: `[About me](#about-me)`. The link after the `#` is the slug version of the title.
+
 ### `assets/main.scss`
 Add any css changes or additions you want to make here after the line `@import 'modern-resume-theme';`
 

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,5 +1,5 @@
 <div class="container intro-container">
-  <h3 id="{{ site.about_title }}">{{ site.about_title | default: "About Me" }}</h3>
+  <h3 id="{{ site.about_title | downcase | replace: ' ', '-' }}">{{ site.about_title | default: "About Me" }}</h3>
   <div class="row clearfix">
     {%- if site.about_profile_image -%}
       <div class="col-xs-12 col-sm-4 col-md-3 no-print">

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,5 +1,6 @@
 <div class="container intro-container">
-  <h3 id="{{ site.about_title | downcase | replace: ' ', '-' }}">{{ site.about_title | default: "About Me" }}</h3>
+  <h3 id="{{ site.about_title | downcase | replace: ' ', '-' | default: 'about-me' }}">{{ site.about_title | default:
+  "About Me" }}</h3>
   <div class="row clearfix">
     {%- if site.about_profile_image -%}
       <div class="col-xs-12 col-sm-4 col-md-3 no-print">

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,5 +1,5 @@
 <div class="container intro-container">
-  <h3>{{ site.about_title | default: "About Me" }}</h3>
+  <h3 id="{{ site.about_title }}">{{ site.about_title | default: "About Me" }}</h3>
   <div class="row clearfix">
     {%- if site.about_profile_image -%}
       <div class="col-xs-12 col-sm-4 col-md-3 no-print">

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,5 +1,5 @@
 <div class="container intro-container">
-  <h3 id="{{ site.about_title | downcase | replace: ' ', '-' | default: 'about-me' }}">{{ site.about_title | default:
+  <h3 id="{{ site.about_title | slugify | default: 'about-me' }}">{{ site.about_title | default:
   "About Me" }}</h3>
   <div class="row clearfix">
     {%- if site.about_profile_image -%}

--- a/_includes/section-list.html
+++ b/_includes/section-list.html
@@ -1,7 +1,7 @@
 {% for item in include.content %}
   <div class="row clearfix layout layout-{{item.layout | default: 'left'}}">
     <div class="col-xs-12 col-sm-4 col-md-3 col-print-12 details">
-      <h4>{{ item.title }}</h4>
+      <h4 id="{{ item.title }}">{{ item.title }}</h4>
       {%- if item.sub_title -%}<p><b>{{ item.sub_title }}</b></p>{%- endif -%}
       {%- if item.caption -%}<p>{{ item.caption }}</p>{%- endif -%}
 

--- a/_includes/section-list.html
+++ b/_includes/section-list.html
@@ -1,7 +1,7 @@
 {% for item in include.content %}
   <div class="row clearfix layout layout-{{item.layout | default: 'left'}}">
     <div class="col-xs-12 col-sm-4 col-md-3 col-print-12 details">
-      <h4 id="{{ item.title | downcase | replace: ' ', '-' }}">{{ item.title }}</h4>
+      <h4 id="{{ item.title | slugify }}">{{ item.title }}</h4>
       {%- if item.sub_title -%}<p><b>{{ item.sub_title }}</b></p>{%- endif -%}
       {%- if item.caption -%}<p>{{ item.caption }}</p>{%- endif -%}
 

--- a/_includes/section-list.html
+++ b/_includes/section-list.html
@@ -1,7 +1,7 @@
 {% for item in include.content %}
   <div class="row clearfix layout layout-{{item.layout | default: 'left'}}">
     <div class="col-xs-12 col-sm-4 col-md-3 col-print-12 details">
-      <h4 id="{{ item.title }}">{{ item.title }}</h4>
+      <h4 id="{{ item.title | downcase | replace: ' ', '-' }}">{{ item.title }}</h4>
       {%- if item.sub_title -%}<p><b>{{ item.sub_title }}</b></p>{%- endif -%}
       {%- if item.caption -%}<p>{{ item.caption }}</p>{%- endif -%}
 

--- a/_includes/v1/education.html
+++ b/_includes/v1/education.html
@@ -1,5 +1,5 @@
 <div class="container education-container">
-  <h3 id="{{ site.education_title }}">{{ site.education_title | default: "Education" }}</h3>
+  <h3 id="{{ site.education_title | downcase | replace: ' ', '-' }}">{{ site.education_title | default: "Education" }}</h3>
   {% for education in site.data.education %}
     {% include {{ education.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=education %}
   {% endfor %}

--- a/_includes/v1/education.html
+++ b/_includes/v1/education.html
@@ -1,5 +1,5 @@
 <div class="container education-container">
-  <h3 id="{{ site.education_title | downcase | replace: ' ', '-' }}">{{ site.education_title | default: "Education" }}</h3>
+  <h3 id="{{ site.education_title | downcase | replace: ' ', '-' | default: 'education' }}">{{ site.education_title | default: "Education" }}</h3>
   {% for education in site.data.education %}
     {% include {{ education.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=education %}
   {% endfor %}

--- a/_includes/v1/education.html
+++ b/_includes/v1/education.html
@@ -1,5 +1,5 @@
 <div class="container education-container">
-  <h3 id="{{ site.education_title | downcase | replace: ' ', '-' | default: 'education' }}">{{ site.education_title | default: "Education" }}</h3>
+  <h3 id="{{ site.education_title | slugify | default: 'education' }}">{{ site.education_title | default: "Education" }}</h3>
   {% for education in site.data.education %}
     {% include {{ education.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=education %}
   {% endfor %}

--- a/_includes/v1/education.html
+++ b/_includes/v1/education.html
@@ -1,5 +1,5 @@
 <div class="container education-container">
-  <h3>{{ site.education_title | default: "Education" }}</h3>
+  <h3 id="{{ site.education_title }}">{{ site.education_title | default: "Education" }}</h3>
   {% for education in site.data.education %}
     {% include {{ education.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=education %}
   {% endfor %}

--- a/_includes/v1/experience.html
+++ b/_includes/v1/experience.html
@@ -1,5 +1,5 @@
 <div class="container experience-container">
-  <h3 id="{{ site.experience_title | downcase | replace: ' ', '-' | default: 'experience' }}">{{ site.experience_title | default: "Experience" }}</h3>
+  <h3 id="{{ site.experience_title | slugify | default: 'experience' }}">{{ site.experience_title | default: "Experience" }}</h3>
   {% for experience in site.data.experience %}
     {% include {{ experience.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=experience %}
   {% endfor %}

--- a/_includes/v1/experience.html
+++ b/_includes/v1/experience.html
@@ -1,5 +1,5 @@
 <div class="container experience-container">
-  <h3>{{ site.experience_title | default: "Experience" }}</h3>
+  <h3 id="{{ site.experience_title }}">{{ site.experience_title | default: "Experience" }}</h3>
   {% for experience in site.data.experience %}
     {% include {{ experience.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=experience %}
   {% endfor %}

--- a/_includes/v1/experience.html
+++ b/_includes/v1/experience.html
@@ -1,5 +1,5 @@
 <div class="container experience-container">
-  <h3 id="{{ site.experience_title }}">{{ site.experience_title | default: "Experience" }}</h3>
+  <h3 id="{{ site.experience_title | downcase | replace: ' ', '-' }}">{{ site.experience_title | default: "Experience" }}</h3>
   {% for experience in site.data.experience %}
     {% include {{ experience.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=experience %}
   {% endfor %}

--- a/_includes/v1/experience.html
+++ b/_includes/v1/experience.html
@@ -1,5 +1,5 @@
 <div class="container experience-container">
-  <h3 id="{{ site.experience_title | downcase | replace: ' ', '-' }}">{{ site.experience_title | default: "Experience" }}</h3>
+  <h3 id="{{ site.experience_title | downcase | replace: ' ', '-' | default: 'experience' }}">{{ site.experience_title | default: "Experience" }}</h3>
   {% for experience in site.data.experience %}
     {% include {{ experience.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=experience %}
   {% endfor %}

--- a/_includes/v1/more.html
+++ b/_includes/v1/more.html
@@ -1,5 +1,5 @@
 <div class="container more-container">
-  <h3 id="{{ site.more_title | downcase | replace: ' ', '-' }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
+  <h3 id="{{ site.more_title | downcase | replace: ' ', '-' | default: 'a-little-bit-more-about-me' }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
   <div class="row clearfix">
     <div class="col-md-12">
       {{ site.more_content | strip | markdownify }}

--- a/_includes/v1/more.html
+++ b/_includes/v1/more.html
@@ -1,5 +1,5 @@
 <div class="container more-container">
-  <h3 id="{{ site.more_title }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
+  <h3 id="{{ site.more_title | downcase | replace: ' ', '-' }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
   <div class="row clearfix">
     <div class="col-md-12">
       {{ site.more_content | strip | markdownify }}

--- a/_includes/v1/more.html
+++ b/_includes/v1/more.html
@@ -1,5 +1,5 @@
 <div class="container more-container">
-  <h3>{{ site.more_title | default: "A Little More About Me" }}</h3>
+  <h3 id="{{ site.more_title }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
   <div class="row clearfix">
     <div class="col-md-12">
       {{ site.more_content | strip | markdownify }}

--- a/_includes/v1/more.html
+++ b/_includes/v1/more.html
@@ -1,5 +1,5 @@
 <div class="container more-container">
-  <h3 id="{{ site.more_title | downcase | replace: ' ', '-' | default: 'a-little-bit-more-about-me' }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
+  <h3 id="{{ site.more_title | slugify | default: 'a-little-bit-more-about-me' }}">{{ site.more_title | default: "A Little More About Me" }}</h3>
   <div class="row clearfix">
     <div class="col-md-12">
       {{ site.more_content | strip | markdownify }}

--- a/_includes/v1/projects.html
+++ b/_includes/v1/projects.html
@@ -1,5 +1,5 @@
 <div class="container projects-container">
-  <h3>{{ site.projects_title | default: "Projects" }}</h3>
+  <h3 id="{{ site.projects_title }}">{{ site.projects_title | default: "Projects" }}</h3>
   {% for project in site.data.projects %}
     {% include {{ project.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=project %}
   {% endfor %}

--- a/_includes/v1/projects.html
+++ b/_includes/v1/projects.html
@@ -1,5 +1,5 @@
 <div class="container projects-container">
-  <h3 id="{{ site.projects_title }}">{{ site.projects_title | default: "Projects" }}</h3>
+  <h3 id="{{ site.projects_title | downcase | replace: ' ', '-' }}">{{ site.projects_title | default: "Projects" }}</h3>
   {% for project in site.data.projects %}
     {% include {{ project.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=project %}
   {% endfor %}

--- a/_includes/v1/projects.html
+++ b/_includes/v1/projects.html
@@ -1,5 +1,5 @@
 <div class="container projects-container">
-  <h3 id="{{ site.projects_title | downcase | replace: ' ', '-' }}">{{ site.projects_title | default: "Projects" }}</h3>
+  <h3 id="{{ site.projects_title | downcase | replace: ' ', '-' | default: 'projects'}}">{{ site.projects_title | default: "Projects" }}</h3>
   {% for project in site.data.projects %}
     {% include {{ project.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=project %}
   {% endfor %}

--- a/_includes/v1/projects.html
+++ b/_includes/v1/projects.html
@@ -1,5 +1,5 @@
 <div class="container projects-container">
-  <h3 id="{{ site.projects_title | downcase | replace: ' ', '-' | default: 'projects'}}">{{ site.projects_title | default: "Projects" }}</h3>
+  <h3 id="{{ site.projects_title | slugify | default: 'projects'}}">{{ site.projects_title | default: "Projects" }}</h3>
   {% for project in site.data.projects %}
     {% include {{ project.layout | default: 'left' | append: ".html" | prepend: "v1/" }} item=project %}
   {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
       {%- if site.version == 2 -%}
         {% for section in site.content %}
           <div class="container {{ section.layout }}-container">
-            <h3 id="{{ section.title | downcase | replace: ' ', '-' }}">{{ section.title }}</h3>
+            <h3 id="{{ section.title | slugify }}">{{ section.title }}</h3>
             {% include {{ section.layout | prepend: "section-" | append: ".html" }} content=section.content %}
           </div>
         {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
       {%- if site.version == 2 -%}
         {% for section in site.content %}
           <div class="container {{ section.layout }}-container">
-            <h3>{{ section.title }}</h3>
+            <h3 id="{{ section.title }}">{{ section.title }}</h3>
             {% include {{ section.layout | prepend: "section-" | append: ".html" }} content=section.content %}
           </div>
         {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
       {%- if site.version == 2 -%}
         {% for section in site.content %}
           <div class="container {{ section.layout }}-container">
-            <h3 id="{{ section.title }}">{{ section.title }}</h3>
+            <h3 id="{{ section.title | downcase | replace: ' ', '-' }}">{{ section.title }}</h3>
             {% include {{ section.layout | prepend: "section-" | append: ".html" }} content=section.content %}
           </div>
         {% endfor %}


### PR DESCRIPTION
H3 and H4 headers can be referenced using the `title` value of the section. For example: 

```
I can link to the [Experience](#experience) section this way

If the link to [About me](#about-me) has a space or capital letters, the link must be lowercase and spaces replaced with dashes.
``` 

To ensure ids are lowercase and don't have spaces, [slugify](https://jekyllrb.com/docs/liquid/filters/#slugify) is called to convert a string into a lowercase URL "slug".