### PR TITLE
Update: Allow visitors to toggle dark theme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,4 +282,4 @@ DEPENDENCIES
   modern-resume-theme!
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,9 @@ website: Your website (eg. https://google.com)(optional)
 # Dark Mode (true/false/never)
 darkmode: false
 
+# Allow users to enable/disable darkmode on their end (using cookies)
+darktoggle: true
+
 # Social links
 twitter_username: jekyllrb
 github_username:  jekyll

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,3 +7,9 @@
     {%- endif -%}
   </p>
 </div>
+
+{% if site.darktoggle == true %}
+<a target="_blank" style="position: fixed; bottom: 20px; right: 20px; " class="button button--sacnite button--round-l text-center" onclick="modifyTheme()">
+    <i id="dark-theme-button" class="fa-lightbulb fa-2x" style="position: sticky; padding-top: 20px;" title="Dark Mode"></i>
+</a>
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,6 +10,6 @@
 
 {% if site.darktoggle == true %}
 <a target="_blank" style="position: fixed; bottom: 20px; right: 20px; " class="button button--sacnite button--round-l text-center" onclick="modifyTheme()">
-    <i id="dark-theme-button" class="fa-lightbulb fa-2x" style="position: sticky; padding-top: 20px;" title="Dark Mode"></i>
+    <i id="dark-theme-button" class="far fa-lightbulb fa-2x" style="position: sticky; padding-top: 20px;" title="Dark Mode"></i>
 </a>
 {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <div class="container header-contianer">
   <div class="row">
     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 header-left">
-      <h1>{{ site.name | escape }}</h1>
+      <h1><a style="color: inherit !important; text-decoration: inherit !important;" href="{{ site.url }}">{{ site.name | escape }}</a></h1>
       <h2>{{ site.title | escape }}</h2>
     </div>
     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 header-right">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,8 +31,16 @@
 
   {%- include footer.html -%}
   {% if site.darkmode == false %}
-    <script src="{{ '/assets/js/index.js' | relative_url }}"></script>
-  {% endif %}
+    <script type="text/javascript">
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          document.body.classList.add("dark");
+        }
+    </script>
+    {% endif %}
+
+    {% if site.darktoggle == true %}
+    <script src="{{ '/assets/js/index.js' | relative_url }}" onload="setupTheme()"></script>
+    {% endif %}
 </body>
 
 </html>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,3 +1,102 @@
-if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-  document.body.classList.add("dark");
+// Deals with enabling/disabling dark theme when required.
+
+var theme = "theme";
+var dark_mode = "dark";
+var light_mode = "light";
+
+/**
+ * A simple wrapper to modify the value of cookies used to keep a track of 
+ * website theme.
+ * 
+ * @param {boolean} enableDarkMode Modifies the value of cookies to 
+ * enable/disable dark mode.
+ * @returns none
+ */
+function modifyCookies(enableDarkMode) {
+    window.localStorage.setItem(theme, enableDarkMode ? dark_mode : light_mode);
 }
+
+/**
+ * Wrapper function to read cookes and check if dark mode is enabled or not.
+ * 
+ * @returns {String} String value containing either `dark_mode`, `light_mode` or null
+ */
+function getCurTheme() {
+    return window.localStorage.getItem(theme);
+}
+
+/**
+ * Function to modify button being used in the dark theme icon.
+ * 
+ * @param {boolean} darkThemeEnabled Boolean indicating if dark theme
+ * has been switched on or off.
+ */
+function toggleButtonIcon(darkThemeEnabled) {
+    let button = document.getElementById("dark-theme-button");
+
+    if (darkThemeEnabled) {
+        button.classList.remove("fas");
+        button.classList.add("far");
+    } else {
+        button.classList.add("fas");
+        button.classList.remove("far");
+    }
+}
+
+/**
+ * Initial setup method - will read the value of stored cookies to check 
+ * if dark mode is enabled or not.
+ * 
+ * Does not make any changes to the values of cookies. Function designed 
+ * to be run when the web-page loads, will simply read the value of existing
+ * cookies (if any), and enable dark mode if required.
+ */
+function setupTheme() {
+    console.log("value: " + getCurTheme());
+
+    // If neither one of the if-else ladder condition is true, do not modify
+    // the theme - ensures that if the user is visiting for the first time,
+    // the theme defaults to the value of `_config.yml/darkmode`
+    if (getCurTheme() === dark_mode)
+        // Dark mode is required
+        document.body.classList.add(dark_mode); // enable dark mode
+    else if (getCurTheme() === light_mode)
+        // Note: Intentionally not removing the element from class list. Ensures
+        // functionality of `darkmode` variable in _configs.yml doesn't break.
+        document.body.classList.remove(dark_mode); // disable dark mode
+
+    // Modify/apply icon for the theme button
+    if (document.body.classList.contains(dark_mode))
+        toggleButtonIcon(true);
+    else
+        toggleButtonIcon(false);
+
+}
+
+/**
+ * Toggles the website theme between dark-mode and normal.
+ */
+function modifyTheme() {
+    if (getCurTheme() === dark_mode) {
+        // Current mode is dark mode, switch to light
+        window.localStorage.setItem(theme, light_mode);
+        document.body.classList.remove(dark_mode);
+        toggleButtonIcon(false);
+    } else {
+        // Assume dark mode is being turned off, enable it
+        window.localStorage.setItem(theme, dark_mode);
+        document.body.classList.add(dark_mode);
+        toggleButtonIcon(true);
+    }
+}
+
+/**
+ * Adding an event listener to detect when the webpage is brought back
+ * in focus. Ensures synced website theme across multiple simultaneous 
+ * sessions, i.e. if the theme is changed in one tab - other tabs will
+ * sync with the changes as soon as they are brought back in focus.
+ */
+document.addEventListener("visibilitychange", function(val) {
+    if (!document.hidden)
+        setupTheme();
+});

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -26,24 +26,6 @@ function getCurTheme() {
 }
 
 /**
- * Function to modify button being used in the dark theme icon.
- * 
- * @param {boolean} darkThemeEnabled Boolean indicating if dark theme
- * has been switched on or off.
- */
-function toggleButtonIcon(darkThemeEnabled) {
-    let button = document.getElementById("dark-theme-button");
-
-    if (darkThemeEnabled) {
-        button.classList.remove("fas");
-        button.classList.add("far");
-    } else {
-        button.classList.add("fas");
-        button.classList.remove("far");
-    }
-}
-
-/**
  * Initial setup method - will read the value of stored cookies to check 
  * if dark mode is enabled or not.
  * 
@@ -52,8 +34,6 @@ function toggleButtonIcon(darkThemeEnabled) {
  * cookies (if any), and enable dark mode if required.
  */
 function setupTheme() {
-    console.log("value: " + getCurTheme());
-
     // If neither one of the if-else ladder condition is true, do not modify
     // the theme - ensures that if the user is visiting for the first time,
     // the theme defaults to the value of `_config.yml/darkmode`
@@ -64,13 +44,6 @@ function setupTheme() {
         // Note: Intentionally not removing the element from class list. Ensures
         // functionality of `darkmode` variable in _configs.yml doesn't break.
         document.body.classList.remove(dark_mode); // disable dark mode
-
-    // Modify/apply icon for the theme button
-    if (document.body.classList.contains(dark_mode))
-        toggleButtonIcon(true);
-    else
-        toggleButtonIcon(false);
-
 }
 
 /**
@@ -81,12 +54,10 @@ function modifyTheme() {
         // Current mode is dark mode, switch to light
         window.localStorage.setItem(theme, light_mode);
         document.body.classList.remove(dark_mode);
-        toggleButtonIcon(false);
     } else {
         // Assume dark mode is being turned off, enable it
         window.localStorage.setItem(theme, dark_mode);
         document.body.classList.add(dark_mode);
-        toggleButtonIcon(true);
     }
 }
 


### PR DESCRIPTION
Add a new sticky button to the bottom-right corner allowing visitors to toggle the dark mode at their end - while deploying the static site, you can choose a global mode, and users can override this at their end. 

For first-time visitors, the value defaults to the value set in `_configs.yml/darkmode`. Stores a cookie for the theme that will be used in subsequent visits. In case multiple sessions to the website are opened, changing the mode in any single instance will reflect across all tabs.

This feature can be turned off by modifying the value of `_config.yml/darktoggle`. Move the existing contents of `/assets/index.js` as an inline script.