### PR TITLE
Google scholar for config.yml and header.html with fa-icon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ pinterest_username: jekyll
 youtube_username: jekyll
 googleplus_username: +jekyll
 orcid_username: 0000-0000-0000-0000
-googlescholar_username: #citations?user=D847cGsAAAAJ&hl=de&oi=ao
+googlescholar_username: D847cGsAAAAJ
 
 # Additional icon links
 additional_links:

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ pinterest_username: jekyll
 youtube_username: jekyll
 googleplus_username: +jekyll
 orcid_username: 0000-0000-0000-0000
+googlescholar_username: #citations?user=D847cGsAAAAJ&hl=de&oi=ao
 
 # Additional icon links
 additional_links:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -97,6 +97,13 @@
             </a>
           </li>
         {%- endif -%}
+        {%- if site.googlescholar_username -%}
+          <li>
+            <a target="_blank" href="https://scholar.google.com/{{ site.googlescholar_username| escape }}" class="button button--sacnite button--round-l">
+              <i class="fab fa-google" title="Google scholar link"></i>
+            </a>
+          </li>
+        {%- endif -%}¬
         {% for link in site.additional_links %}
           <li>
             {% include a.html href=link.url class="button button--sacnite button--round-l" %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -99,7 +99,7 @@
         {%- endif -%}
         {%- if site.googlescholar_username -%}
           <li>
-            <a target="_blank" href="https://scholar.google.com/{{ site.googlescholar_username| escape }}" class="button button--sacnite button--round-l">
+            <a target="_blank" href="https://scholar.google.com/citations?user={{ site.googlescholar_username| escape }}" class="button button--sacnite button--round-l">
               <i class="fab fa-google" title="Google scholar link"></i>
             </a>
           </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -103,7 +103,7 @@
               <i class="fab fa-google" title="Google scholar link"></i>
             </a>
           </li>
-        {%- endif -%}¬
+        {%- endif -%}
         {% for link in site.additional_links %}
           <li>
             {% include a.html href=link.url class="button button--sacnite button--round-l" %}


### PR DESCRIPTION
Many users are academics who often include their Google Scholar link. Here is the method for including this, using the font awesome fa-google icon. The included example (commented out) in _config.yml for google_scholar user: Charles Darwin.