### PR TITLE
Vertically center header content

### DIFF
--- a/_sass/modern-resume-theme.scss
+++ b/_sass/modern-resume-theme.scss
@@ -64,8 +64,12 @@
   flex-direction: row;
 
   .details {
+    display: flex;
+    flex-direction: column;
     text-align: left;
-
+    justify-content: center;
+    vertical-align: middle;
+    
     p {
       margin-bottom: 3px;
       font-size: 1.6rem;


### PR DESCRIPTION
The project title/header (don't know what to call it) is not vertically centered - this is how it looks like when populated with larger amount of text;

![Screenshot from 2021-08-19 20-52-47](https://user-images.githubusercontent.com/22884507/130097347-9525158d-1367-4e46-a509-f1fd9196a443.png)

---

Center this text - here's what the update looks like;

![Screenshot from 2021-08-19 20-53-48](https://user-images.githubusercontent.com/22884507/130097482-5c63d9b8-7d71-4752-b4ad-ff11bba2e342.png)
