### PR TITLE
Allow displaying weak borders for list section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,23 @@ content:
     layout: list # Type of content section (list/text)
     content:
       - layout: left
+        border: weak  # Value of `weak` will display a weak border below this item. # Any 
+                      # other value (or no value) means no border will be displayed
+        title: Project name
+        link: Link to project (eg. sproogen.github.io/modern-resume-theme)(optional)
+        link_text: Link Text
+        additional_links:
+          - title:  Github page for project (eg. sproogen/modern-resume-theme)
+            icon: fab fa-github
+            url: Link to project (eg. sproogen.github.io/modern-resume-theme)(optional)
+          - title:  Github page for project (eg. sproogen/modern-resume-theme)
+            icon: fab fa-github
+            url: Link to project (eg. sproogen.github.io/modern-resume-theme)(optional)
+        quote: >
+          Short overview of the project (optional)
+        description: | # this will include new lines to allow paragraphs
+          Description about the work on/with the project
+      - layout: left
         title: Project name
         link: Link to project (eg. sproogen.github.io/modern-resume-theme)(optional)
         link_text: Link Text

--- a/_includes/section-list.html
+++ b/_includes/section-list.html
@@ -1,5 +1,5 @@
 {% for item in include.content %}
-  <div class="row clearfix layout layout-{{item.layout | default: 'left'}}">
+  <div class="row clearfix layout layout-{{item.layout | default: 'left'}} border-{{item.border | default: 'no'}}">
     <div class="col-xs-12 col-sm-4 col-md-3 col-print-12 details">
       <h4>{{ item.title }}</h4>
       {%- if item.sub_title -%}<p><b>{{ item.sub_title }}</b></p>{%- endif -%}

--- a/_sass/modern-resume-theme.scss
+++ b/_sass/modern-resume-theme.scss
@@ -58,6 +58,11 @@
   }
 }
 
+.border-weak  {
+  padding-bottom: 8px;
+  border-bottom: dashed 1px #CCCCCC;
+}
+
 .layout {
   margin-top: 3rem;
   display: flex;


### PR DESCRIPTION
A list section with many elements starts to look cluttered - to solve this, allow each element to individually contain a weak border creating a visual boundary between two items. Here's an example;

![Screenshot](https://user-images.githubusercontent.com/22884507/130097347-9525158d-1367-4e46-a509-f1fd9196a443.png)

---

With weak boundaries, users can decide to add a weak boundary to individual elements, allowing visual distinction between two consecutive elements;

![Screenshot](https://user-images.githubusercontent.com/22884507/130102018-b8e6d963-225b-4a60-9fa2-a0d08512cf84.png)

---
To display a weak boundary below an element, simply add a `border: weak` tag to the list element. Any other value for the tag (or no value) will be ignored - i.e. no bottom border will be displayed
