### PR TITLE
Fix typos

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<div class="container header-contianer">
+<div class="container header-container">
   <div class="row">
     <div class="col-xs-12 col-sm-6 col-md-6 col-lg-8 header-left">
       <h1>{{ site.name | escape }}</h1>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -162,7 +162,7 @@ body {
   }
 }
 
-.header-contianer {
+.header-container {
   margin-top:50px;
 }
 

--- a/_sass/modern-resume-theme.scss
+++ b/_sass/modern-resume-theme.scss
@@ -14,7 +14,7 @@
 }
 
 @media screen and (max-width: 768px) {
-  .header-contianer div{
+  .header-container div{
     text-align: center;
   }
 


### PR DESCRIPTION
Fixes a typo where the word 'container' is spelled as 'contianer' in
3 different files:

- _includes/header.html
- _sass/base.scss
- _sass/modern-resume-theme.scss