### PR TITLE
Feature: Automatically edit  last time updated

### DIFF
--- a/.github/workflows/update_lasttime.yml
+++ b/.github/workflows/update_lasttime.yml
@@ -1,0 +1,28 @@
+name: Last Updated Time
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update-last-time:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v3
+    
+    - name: Get current time
+      uses: josStorer/get-current-time@v2.0.2
+      id: current-time
+      with:
+        format: Do MMM YYYY
+    
+    - name: Update _config.yml
+      uses: fjogeleit/yaml-update-action@v0.12.3
+      with:
+        valueFile: '_config.yml'
+        propertyPath: 'last_updated_time'
+        value: ${{ steps.current-time.outputs.formattedTime }}
+        commitChange: true
+        message: 'Last Time Updated.'

--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,9 @@ additional_links:
 # gtag: "UA-00000000-0"
 # google_analytics: "UA-00000000-0"
 
+# Last time the website has been updated: This variable automatically updates after each push in master branch by 'update_lasttime.yml' workflow
+last_updated_time: null
+
 # About Section
 # about_title: About Me (Use this to override about section title)
 about_profile_image: Directory of profile image (eg. images/profile.jpg)

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -8,6 +8,9 @@
       </div>
     {%- endif -%}
     <div class="{{ 'col-xs-12 ' }}{%- if site.about_profile_image -%}col-sm-8 col-md-9 col-print-12{%- endif -%}">
+      {%- if site.last_updated_time != null -%}
+        <i style="font-size: 12px;">(Last Updated: {{ site.last_updated_time }})</i>
+      {%- endif -%}
       {{ site.about_content | strip | markdownify }}
     </div>
   </div>


### PR DESCRIPTION
Hi,

I implemented a workflow that enables users to set the last time their websites have been updated. This helps their audience better know how long the information on the website is up to date. Its default value is `null`, disabling this feature in the website. If you are willing to, I can replace `workflow_dispatch` with `push on master branch` to let the user update this feature manually by running the workflow in the Actions section.