### PR TITLE
fix: Specify Jekyll version in Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   jekyll:
-    image: jekyll/jekyll
+    image: jekyll/jekyll:3.8
     container_name: modern-resume-theme
     command: jekyll serve --watch --force_polling --verbose
     ports:


### PR DESCRIPTION
If no tag is specified, the latest version will be retrieved (v4) and the lock file is incompatible: 

```
modern-resume-theme  | Bundler 2.3.25 is running, but your lockfile was generated with 2.1.4. Installing Bundler 2.1.4 and restarting using that version.
modern-resume-theme  | Fetching gem metadata from https://rubygems.org/.
modern-resume-theme  | Fetching bundler 2.1.4
modern-resume-theme  | Installing bundler 2.1.4
modern-resume-theme  | Fetching gem metadata from https://rubygems.org/.........
modern-resume-theme  | modern-resume-theme-2.0.10 requires ruby version ~> 2.0, which is incompatible
modern-resume-theme  | with the current version, ruby 3.1.1p18
```

There is a `3.9` tag on DockerHub, but 3.8 seems to work